### PR TITLE
initial appveyor.yml CI config

### DIFF
--- a/MediaDevices.sln
+++ b/MediaDevices.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaDevices", "MediaDevices\MediaDevices.csproj", "{E5353CB2-1320-4E96-A15E-551BA0B51105}"
 EndProject
 Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "MediaDevicesDoc", "MediaDevicesDoc\MediaDevicesDoc.shfbproj", "{15DBA1E6-2C21-40AC-BD19-67926C3442AC}"
+	ProjectSection(ProjectDependencies) = postProject
+		{E5353CB2-1320-4E96-A15E-551BA0B51105} = {E5353CB2-1320-4E96-A15E-551BA0B51105}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaDevicesUnitTest", "MediaDevicesUnitTest\MediaDevicesUnitTest.csproj", "{068A3C3C-99B6-4CDF-9DCA-DAAE229B8615}"
 EndProject

--- a/MediaDevices/MediaDevices.csproj
+++ b/MediaDevices/MediaDevices.csproj
@@ -105,7 +105,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Release'">
-    <Exec Command="nuget pack $(ProjectFileName) -Prop Configuration=Release">
+    <Exec Command="nuget pack $(ProjectDir)$(ProjectFileName) -Prop Configuration=$(ConfigurationName) -Prop Platform=AnyCPU">
     </Exec>
   </Target>
 </Project>

--- a/MediaDevicesDoc/MediaDevicesDoc.shfbproj
+++ b/MediaDevicesDoc/MediaDevicesDoc.shfbproj
@@ -54,6 +54,8 @@
       <NamespaceSummaryItem name="(global)" isDocumented="True">Namespace for Media Devices</NamespaceSummaryItem>
       <NamespaceSummaryItem name="MediaDevices" isDocumented="True">Namespace for Media Devices</NamespaceSummaryItem>
     </NamespaceSummaries>
+    <ComponentPath>$(MSBuildThisFileDirectory)..\packages\EWSoftware.SHFB.NETFramework.4.7</ComponentPath>
+    <SHFBROOT Condition=" '$(SHFBROOT)' == '' ">$(MSBuildThisFileDirectory)..\packages\EWSoftware.SHFB.2017.5.15.0\tools\</SHFBROOT>
   </PropertyGroup>
   <!-- There are no properties for these groups.  AnyCPU needs to appear in order for Visual Studio to perform
 			 the build.  The others are optional common platform types that may appear. -->

--- a/MediaDevicesDoc/packages.config
+++ b/MediaDevicesDoc/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EWSoftware.SHFB" version="2017.5.15.0" targetFramework="net45" />
+  <package id="EWSoftware.SHFB.NETFramework" version="4.7" targetFramework="net45" />
+</packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,51 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+
+
+environment:
+  matrix:
+    - PlatformToolset: v140
+
+platform:
+    - Any CPU
+
+configuration:
+    - Release
+    #- Debug
+
+
+install:
+    - nuget restore "%APPVEYOR_BUILD_FOLDER%"\MediaDevicesDoc\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\packages
+
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild MediaDevices.sln /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+
+        Push-AppveyorArtifact "MediaDevices\bin\$env:CONFIGURATION\MediaDevices.dll" -FileName MediaDevices.dll
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140") {
+            $ZipFileName = "MediaDevices_$($env:APPVEYOR_REPO_TAG_NAME).zip"
+            7z a $ZipFileName MediaDevices\bin\$env:CONFIGURATION\MediaDevices.dll
+        }
+
+artifacts:
+  - path: MediaDevices_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v140
+        configuration: Release


### PR DESCRIPTION
- initial appveyor.yml CI config
- added sandcastle nuget packages.config to build via msbuild, see https://stackoverflow.com/questions/33668365/how-to-generate-documentation-using-sandcastle-nuget-package-ewsoftware-shfb
- added missing build dependency, needed for /m (parallel builds) option of msbuild
- modified nuget pack due to issue reported also at http://timjames.me/blog/2015/07/29/nuget-pack-fails-with-exited-with-code-1/

Build see:
https://ci.appveyor.com/project/chcg/mediadevices/build/1.0.11

Not done:
- prepare proper release to github, see https://www.appveyor.com/docs/deployment/github/#provider-settings
- publish nuget package, see https://www.codeproject.com/Tips/806257/Automating-NuGet-Package-Creation-using-AppVeyor