### PR TITLE
Fix exception being thrown by Regex.IsMatch when item.Name is null

### DIFF
--- a/Src/MediaDevicesShare/Internal/Item.cs
+++ b/Src/MediaDevicesShare/Internal/Item.cs
@@ -396,7 +396,7 @@ namespace MediaDevices.Internal
 
                     if (item != null)
                     {
-                        if (pattern == null || Regex.IsMatch(item.Name, pattern, RegexOptions.IgnoreCase))
+                        if (pattern == null || (item.Name != null && Regex.IsMatch(item.Name, pattern, RegexOptions.IgnoreCase)))
                         {
                             yield return item;
                         }


### PR DESCRIPTION
When iterating though all the files and folders on my Samsung S23, `EnumerateDirectories` and `EnumerateFiles` were throwing exceptions when using a pattern. After running the library from source, I noticed the crash happened [here on line 399](https://github.com/RonSijm/MediaDevices/blob/c26ed94773c2f3d2e1c98f8b662c7acb1474f910/Src/MediaDevicesShare/Internal/Item.cs#L399) when the item.Name was null (for no apparent reason) - and Regex.IsMatch threw an exception.

The solution here assumes that if the item.Name is null, it considers it not to be matching the specified pattern