### PR TITLE
fix package issue + correct nuspec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
       Solution: MediaDevices.sln
       NugetSpc: MediaDevices.nuspec
     strategy:
+      fail-fast: false
       matrix:
         build_configuration: [Release, Debug]
 
@@ -57,7 +58,7 @@ jobs:
     - name: MSBuild of solution
       run: msbuild $env:Solution /p:configuration="${{ matrix.build_configuration }}" /verbosity:minimal
 
-#    - name: Nuget pack nuspec
-#      if: matrix.build_configuration == 'Release'
-#      working-directory: .\Nuget\
-#      run: nuget pack $env:NugetSpc -properties Configuration=Release
+    - name: Nuget pack nuspec
+      if: matrix.build_configuration == 'Release'
+      working-directory: .\Nuget\
+      run: nuget pack $env:NugetSpc -properties Configuration=Release

--- a/Nuget/MediaDevices.nuspec
+++ b/Nuget/MediaDevices.nuspec
@@ -12,7 +12,7 @@
     <projectUrl>https://github.com/Bassman2/MediaDevices</projectUrl>
     <description>API to communicate with MTP / WPD devices like smart phones, tablets and cameras. Documentation included.</description>
     <releaseNotes>Add support for .NET 8.</releaseNotes>
-    <copyright>Copyright 2016 - 2023 (c) by Ralf Beckers</copyright>
+    <copyright>Copyright 2016 - 2024 (c) by Ralf Beckers</copyright>
     <repository type="git" url="https://github.com/Bassman2/MediaDevices" />
     <tags>MTP WPD PortableDevice PortableDevices API phone tablet</tags>
     <readme>docs\README.md</readme>
@@ -20,12 +20,7 @@
       <group targetFramework="net8.0-windows7.0" />
       <group targetFramework="net7.0-windows7.0" />
       <group targetFramework="net6.0-windows7.0" />
-      <group targetFramework="net5.0-windows7.0" />
-      <group targetFramework=".NETCoreApp3.1-windows7.0" />
-      <group targetFramework=".NETCoreApp2.1-windows7.0" />
       <group targetFramework=".NETFramework4.8" />
-      <group targetFramework=".NETFramework4.5" />
-      <group targetFramework=".NETFramework4.0" />
     </dependencies>
   </metadata>
   
@@ -33,12 +28,7 @@
     <file src="..\Src\MediaDevices80\bin\Release\net8.0-windows7.0\**" target="lib/net8.0-windows7.0" />
     <file src="..\Src\MediaDevices70\bin\Release\net7.0-windows7.0\**" target="lib/net7.0-windows7.0" />
     <file src="..\Src\MediaDevices60\bin\Release\net6.0-windows7.0\**" target="lib/net6.0-windows7.0" />
-    <file src="..\Src\MediaDevices50\bin\Release\net5.0-windows7.0\**" target="lib/net5.0-windows7.0" />
-    <file src="..\Src\MediaDevicesCore31\bin\Release\netcoreapp3.1\**" target="lib/netcoreapp3.1-windows7.0" />
-    <file src="..\Src\MediaDevicesCore21\bin\Release\netcoreapp2.1\**" target="lib/netcoreapp2.1-windows7.0" />
     <file src="..\Src\MediaDevicesFramework48\bin\Release\**" target="lib/net48" />	
-    <file src="..\Src\MediaDevicesFramework45\bin\Release\**" target="lib/net45" />	
-    <file src="..\Src\MediaDevicesFramework40\bin\Release\**" target="lib/net40" />	
     <file src="..\Doc\MediaDevicesDoc\Help\MediaDevices.chm" target="content" />
     <file src="..\README.md" target="docs\" />
     <file src="..\LICENSE*" target="content" />

--- a/Test/MediaDevicesUnitTestFramework48/MediaDevicesUnitTestFramework48.csproj
+++ b/Test/MediaDevicesUnitTestFramework48/MediaDevicesUnitTestFramework48.csproj
@@ -4,8 +4,6 @@
   <Import Project="..\..\packages\Microsoft.Testing.Extensions.Telemetry.1.5.0\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\..\packages\Microsoft.Testing.Extensions.Telemetry.1.5.0\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\..\packages\Microsoft.Testing.Platform.MSBuild.1.5.0\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\..\packages\Microsoft.Testing.Platform.MSBuild.1.5.0\build\Microsoft.Testing.Platform.MSBuild.props')" />
   <Import Project="..\..\packages\Microsoft.Testing.Platform.1.5.0\build\netstandard2.0\Microsoft.Testing.Platform.props" Condition="Exists('..\..\packages\Microsoft.Testing.Platform.1.5.0\build\netstandard2.0\Microsoft.Testing.Platform.props')" />
-  <Import Project="../../packages/Microsoft.Testing.Platform.MSBuild.1.4.3/build/netstandard2.0/Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('../../packages/Microsoft.Testing.Platform.MSBuild.1.4.3/build/netstandard2.0/Microsoft.Testing.Platform.MSBuild.props')" />
-  <Import Project="../../packages/Microsoft.Testing.Platform.1.4.3/build/netstandard2.0/Microsoft.Testing.Platform.props" Condition="Exists('../../packages/Microsoft.Testing.Platform.1.4.3/build/netstandard2.0/Microsoft.Testing.Platform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -135,8 +133,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Microsoft.Testing.Platform.1.4.3\build\netstandard2.0\Microsoft.Testing.Platform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Testing.Platform.1.4.3\build\netstandard2.0\Microsoft.Testing.Platform.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.Testing.Platform.MSBuild.1.4.3\build\netstandard2.0\Microsoft.Testing.Platform.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Testing.Platform.MSBuild.1.4.3\build\netstandard2.0\Microsoft.Testing.Platform.MSBuild.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Testing.Platform.1.5.0\build\netstandard2.0\Microsoft.Testing.Platform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Testing.Platform.1.5.0\build\netstandard2.0\Microsoft.Testing.Platform.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Testing.Platform.MSBuild.1.5.0\build\Microsoft.Testing.Platform.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Testing.Platform.MSBuild.1.5.0\build\Microsoft.Testing.Platform.MSBuild.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Testing.Platform.MSBuild.1.5.0\build\Microsoft.Testing.Platform.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Testing.Platform.MSBuild.1.5.0\build\Microsoft.Testing.Platform.MSBuild.targets'))" />

--- a/Test/MediaDevicesUnitTestFramework48/app.config
+++ b/Test/MediaDevicesUnitTestFramework48/app.config
@@ -12,23 +12,23 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Testing.Extensions.Telemetry" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.3.0" newVersion="1.4.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Testing.Extensions.TrxReport.Abstractions" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.3.0" newVersion="1.4.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Testing.Extensions.VSTestBridge" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.1.0" newVersion="1.4.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Testing.Platform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.3.0" newVersion="1.4.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Testing.Platform.MSBuild" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.4.3.0" newVersion="1.4.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.0.0" newVersion="1.5.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.TestPlatform.CoreUtilities" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
D:\a\MediaDevices\MediaDevices\Test\MediaDevicesUnitTestFramework48\MediaDevicesUnitTestFramework48.csproj(138,5): error : This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is ..\..\packages\Microsoft.Testing.Platform.1.4.3\build\netstandard2.0\Microsoft.Testing.Platform.props.
